### PR TITLE
fix: Using Flags().*Var() functions for better flag usability

### DIFF
--- a/cli/countline.go
+++ b/cli/countline.go
@@ -11,8 +11,13 @@ import (
 
 var linecount *cobra.Command
 
+// Define global variables to store the value of flags
+var file string
+
 func init() {
-	LinecountCmd().Flags().StringP("file", "f", "", "File to operate on")
+	// Use the StringVarP to bind flag values to variables
+	LinecountCmd().Flags().StringVarP(&file, "file", "f", "", "File to operate on")
+
 	LinecountCmd().MarkFlagRequired("file")
 	rootcmd.AddCommand(LinecountCmd())
 }
@@ -27,9 +32,9 @@ func count(filename string) (int, error) {
 }
 
 func LinecountRun(cmd *cobra.Command, args []string) error {
-	filename, _ := cmd.Flags().GetString("file")
+
 	//Conduct a series of file checks
-	fs := filesys.File(filename).CheckFile().CheckNotBinary()
+	fs := filesys.File(file).CheckFile().CheckNotBinary()
 
 	if fs.Err != nil {
 		fmt.Println(fs.Err)

--- a/cli/version.go
+++ b/cli/version.go
@@ -9,9 +9,13 @@ import (
 var Version string
 var versionCmd *cobra.Command
 
-// Added the versioncmd command to the rootcmd
+// Define global variables to store the value of flags
+var versionFlag string
+
 func init() {
-	VersionCmd().Flags().StringP("version", "v", "", "File's version")
+	// Use the StringVarP to bind flag values to variables
+	VersionCmd().Flags().StringVarP(&versionFlag, "version", "v", "", "File's version")
+
 	rootcmd.AddCommand(VersionCmd())
 }
 
@@ -23,17 +27,14 @@ func GetVersion() string {
 	return Version
 }
 
-//Run (1)Receive pointer for the command being executed
-//    (2)args []string: Parameters input in the command line.
-//       This slice contains all parameters except for the command name.
-
 func VersionCmd() *cobra.Command {
 	if versionCmd == nil {
 		versionCmd = &cobra.Command{
 			Use:   "version",
 			Short: "Show current version",
 			Run: func(cmd *cobra.Command, args []string) {
-				fmt.Println("fops " + Version)
+				// Use the global variable versionFlag
+				fmt.Println("fops " + Version + " " + versionFlag)
 			},
 		}
 	}


### PR DESCRIPTION
@CheyiLin 
I changed ChecksumCmd().Flags().Bool(), ChecksumCmd().Flags().StringP()
to ChecksumCmd().Flags().BoolVar() and VersionCmd().Flags().StringVarP( )